### PR TITLE
Use current user's $HOME for Default Transmission Config Path

### DIFF
--- a/pia-tools
+++ b/pia-tools
@@ -33,7 +33,8 @@ if [[ -z "$PIA_CLIENT_ID_FILE" ]]; then
     PIA_CLIENT_ID_FILE="$PIA_CONFIG_DIR/clientid"
 fi
 if [[ -z "$TRANSMISSION_SETTINGS_FILE" ]]; then
-    TRANSMISSION_SETTINGS_FILE='/home/dl/.config/transmission-daemon/settings.json'
+    current_user_home=$(eval echo ~$(logname))
+    TRANSMISSION_SETTINGS_FILE="$curent_user_home/.config/transmission-daemon/settings.json"
 fi
 if [[ -z "$PIA_OPEN_PORT_FILE" ]]; then
     PIA_OPEN_PORT_FILE="$PIA_CONFIG_DIR/open_port"

--- a/pia-tools.groff
+++ b/pia-tools.groff
@@ -81,7 +81,7 @@ File holding your PIA credentials (default: $PIA_CONFIG_DIR/passwd)
 .IP \fBPIA_CLIENT_ID_FILE\fR
 File where your client-ID is stored (default: $PIA_CONFIG_DIR/clientid)
 .IP \fBTRANSMISSION_SETTINGS_FILE\fR
-Path to transmission config (default: /home/dl/.config/transmission-daemon/settings.json)
+Path to transmission config (default: (current user's) $HOME/.config/transmission-daemon/settings.json)
 .IP \fBPIA_OPEN_PORT_FILE\fR
 Path to the file where the currently open (forwarded) port is stored (default: $PIA_CONFIG_DIR/open_port)
 .IP \fBVIRT_NET_DEV\fR


### PR DESCRIPTION
This uses logname with eval echo for tilde expansion to get the user's home directory (since run as root).
